### PR TITLE
Fix indexer status display to show "Stopped" instead of "Failed" when…

### DIFF
--- a/src/routes/settings.go
+++ b/src/routes/settings.go
@@ -156,7 +156,7 @@ func SettingsRoutes(router *gin.Engine, title string, database *db.Database, _bl
 		isOnBattery := host.IsOnBattery()
 		indexerRunning := database.SettingsGetValue("indexerRunning")
 		if indexerRunning != "true" || (isOnBattery && !indexerOnBatteryBool) {
-			baseIndexerStatus = "Stopped"
+			baseIndexerStatus = "stopped"
 		}
 		c.SecureJSON(http.StatusOK, gin.H{
 			"status": baseIndexerStatus,


### PR DESCRIPTION
… disabled

When the indexer is purposefully disabled (either manually or via battery settings), the status now correctly displays as "Stopped" in gray instead of potentially showing "Failed" in red. This change fixes a case sensitivity issue where the backend was sending "Stopped" (capitalized) but the frontend expected "stopped" (lowercase) for proper color coding.

Changes:
- Updated /settings/indexer/status endpoint to return lowercase "stopped"
- This matches the frontend expectation in settings.ts:239
- Improves UX by clearly distinguishing intentional stops from failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)