### PR TITLE
Add indexer toggle to systray menu

### DIFF
--- a/main_desktop.go
+++ b/main_desktop.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"YourPlace/src/core/db"
+	"YourPlace/src/core/db/blockchain"
 	"YourPlace/src/core/host"
 	"runtime"
 	"strconv"
@@ -13,6 +14,13 @@ import (
 
 func runSystray(database *db.Database) {
 	systray.Run(func() { SystrayOnReady(database) }, func() { host.Shutdown(0) })
+}
+func getIndexerMenuText(database *db.Database) string {
+	indexerRunning := database.SettingsGetValue("indexerRunning")
+	if indexerRunning == "true" {
+		return "Indexer: Enabled"
+	}
+	return "Indexer: Disabled"
 }
 
 func SystrayOnReady(database *db.Database) {
@@ -25,6 +33,7 @@ func SystrayOnReady(database *db.Database) {
 	mUI := systray.AddMenuItem("Open YourPlace", "Open YourPlace in your browser")
 	mUI.SetIcon(favicon)
 	mSettings := systray.AddMenuItem("Settings", "YourPlace Settings")
+	mIndexer := systray.AddMenuItem(getIndexerMenuText(database), "Toggle blockchain indexer on/off")
 	mQuit := systray.AddMenuItem("Quit", "Quit YourPlace Server")
 	go func() {
 		for {
@@ -35,6 +44,9 @@ func SystrayOnReady(database *db.Database) {
 				host.OpenBrowser(protocol + "://" + domain + ":" + strconv.Itoa(port))
 			case <-mSettings.ClickedCh:
 				host.OpenBrowser(protocol + "://" + domain + ":" + strconv.Itoa(port) + "/settings")
+			case <-mIndexer.ClickedCh:
+				blockchain.ToggleIndexer(database)
+				mIndexer.SetTitle(getIndexerMenuText(database))
 			}
 		}
 	}()


### PR DESCRIPTION
Add a single menu entry that allows toggling the blockchain indexer on/off directly from the systray menu. The menu item clearly shows the current status ("Indexer: Enabled" or "Indexer: Disabled") and toggles the state when clicked.

Implementation:
- Added getIndexerMenuText() helper to display current indexer status
- Added "Indexer: Enabled/Disabled" menu item with tooltip
- Click handler calls blockchain.ToggleIndexer() and updates menu text
- Positioned between Settings and Quit menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)