### PR TITLE
Update initial indexer status display to show capitalized "Stopped"

### DIFF
--- a/src/templates/pages/settings.tmpl
+++ b/src/templates/pages/settings.tmpl
@@ -172,7 +172,7 @@
                                         </div>
                                     </div>
                                     <div class="col-4" id="indexerStatusDiv">
-                                        <span>Indexer Status: </span><span id="indexerStatusText">stopped</span>
+                                        <span>Indexer Status: </span><span id="indexerStatusText">Stopped</span>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
The HTML template now displays "Stopped" (capitalized) as the initial value to be consistent with other status displays like "Running", "Complete", and "Failed". This ensures the UI shows proper capitalization both before and after the JavaScript updates the status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)