### PR TITLE
Sync systray and settings page indexer toggle states

### DIFF
--- a/main_desktop.go
+++ b/main_desktop.go
@@ -8,6 +8,7 @@ import (
 	"YourPlace/src/core/host"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/getlantern/systray"
 )
@@ -35,7 +36,9 @@ func SystrayOnReady(database *db.Database) {
 	mSettings := systray.AddMenuItem("Settings", "YourPlace Settings")
 	mIndexer := systray.AddMenuItem(getIndexerMenuText(database), "Toggle blockchain indexer on/off")
 	mQuit := systray.AddMenuItem("Quit", "Quit YourPlace Server")
+	ticker := time.NewTicker(6 * time.Second)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-mQuit.ClickedCh:
@@ -46,6 +49,8 @@ func SystrayOnReady(database *db.Database) {
 				host.OpenBrowser(protocol + "://" + domain + ":" + strconv.Itoa(port) + "/settings")
 			case <-mIndexer.ClickedCh:
 				blockchain.ToggleIndexer(database)
+				mIndexer.SetTitle(getIndexerMenuText(database))
+			case <-ticker.C:
 				mIndexer.SetTitle(getIndexerMenuText(database))
 			}
 		}

--- a/src/typescript/pages/settings.ts
+++ b/src/typescript/pages/settings.ts
@@ -89,7 +89,8 @@ import {Sleep} from "../util/time";
 
             /* Cron Jobs */
             setInterval(getBaseIndexerProgress, 300000); // 5 minutes
-            setInterval(getIndexerStatus, 6000); // 1 minute
+            setInterval(getIndexerStatus, 6000); // 6 seconds
+            setInterval(getIndexerRunning, 6000); // 6 seconds - keep checkbox in sync with systray
         }
 
         /* Getting Current Settings Values */


### PR DESCRIPTION
This commit fixes the synchronization issue between the systray indexer toggle and the settings page checkbox. Changes include:

- Added polling (every 6 seconds) to settings page to sync checkbox state with systray toggle changes
- Added polling (every 6 seconds) to systray to sync menu text with settings page checkbox changes
- Fixed comment that incorrectly said "1 minute" when it was 6 seconds

Now when you toggle the indexer from either the systray or the settings page, the other UI will update within 6 seconds to stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)