### PR TITLE
Remove database snapshot functions

### DIFF
--- a/src/typescript/pages/settings.ts
+++ b/src/typescript/pages/settings.ts
@@ -332,12 +332,6 @@ import {Sleep} from "../util/time";
                 return "";
             }
         }
-        async function getDatabaseSnapshotDirectory() {
-            let response = await HttpGetJson("/settings/database/snapshotDirectory");
-            if (response[0] === 200) {
-                DOM.databaseSnapshotDirectory.textContent = "Export location: " + response[1].snapshotDirectory;
-            }
-        }
         async function getServerLogs() {
             DOM.logsView.textContent = "";
             let response = await HttpGetJson("/settings/server/logs/view");
@@ -574,86 +568,6 @@ import {Sleep} from "../util/time";
                 DOM.ipfsPinningKey.value = "";
                 ShowSavedToast();
             }
-        }
-        async function setDatabaseExportSnapshot() {
-            const originalText = DOM.databaseExportSnapshotBtn.textContent;
-            DOM.databaseExportSnapshotBtn.disabled = true;
-            DOM.databaseExportSnapshotBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Exporting...';
-            const data = {
-                snapshot: "export",
-            }
-            let response = await HttpPostJson("/settings/database/exportSnapshot", data, DOM.csrfToken.value);
-            if (response[0] === 200) {
-                ShowToast("Database snapshot export started");
-            } else {
-                ShowDialogModal(response[1].status);
-                DOM.databaseExportSnapshotBtn.textContent = originalText;
-                DOM.databaseExportSnapshotBtn.disabled = false;
-                return
-            }
-            const interval = setInterval(async() => {
-                // Polls backend every 5 second for database snapshot export status
-                let response = await HttpGetJson("/settings/database/exportSnapshotStatus");
-                if (response[0] === 200) {
-                    let status = response[1].status;
-                    if (status == "complete") {
-                        ShowToast("Database snapshot exported");
-                        DOM.databaseExportSnapshotBtn.textContent = originalText;
-                        DOM.databaseExportSnapshotBtn.disabled = false;
-                        clearInterval(interval);
-                    } else if (status == "failed") {
-                        ShowToast("Failed to export database snapshot");
-                        DOM.databaseExportSnapshotBtn.textContent = originalText;
-                        DOM.databaseExportSnapshotBtn.disabled = false;
-                        clearInterval(interval);
-                    }
-                } else {
-                    ShowToast("Cannot get database export status")
-                    DOM.databaseExportSnapshotBtn.textContent = originalText;
-                    DOM.databaseExportSnapshotBtn.disabled = false;
-                    clearInterval(interval);
-                }
-            }, 5000)
-        }
-        async function setDatabaseImportSnapshot() {
-            const originalText = DOM.databaseImportSnapshotBtn.textContent;
-            DOM.databaseImportSnapshotBtn.disabled = true;
-            DOM.databaseImportSnapshotBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Importing...';
-            const data = {
-                snapshot: "import",
-            }
-            let response = await HttpPostJson("/settings/database/importSnapshot", data, DOM.csrfToken.value);
-            if (response[0] === 200) {
-                ShowToast("Database snapshot import started");
-            } else {
-                ShowDialogModal(response[1].status);
-                DOM.databaseImportSnapshotBtn.textContent = originalText;
-                DOM.databaseImportSnapshotBtn.disabled = false;
-                return
-            }
-            const interval = setInterval(async() => {
-                // Polls backend every 5 seconds for status of database snapshot import
-                let response = await HttpGetJson("/settings/database/importSnapshotStatus");
-                if (response[0] === 200) {
-                    let status = response[1].status;
-                    if (status == "complete") {
-                        ShowToast("Database snapshot imported");
-                        DOM.databaseImportSnapshotBtn.textContent = originalText;
-                        DOM.databaseImportSnapshotBtn.disabled = false;
-                        clearInterval(interval);
-                    } else if (status == "failed") {
-                        ShowToast("Failed to import database snapshot");
-                        DOM.databaseImportSnapshotBtn.textContent = originalText;
-                        DOM.databaseImportSnapshotBtn.disabled = false;
-                        clearInterval(interval);
-                    }
-                } else {
-                    ShowToast("Cannot get database import status")
-                    DOM.databaseImportSnapshotBtn.textContent = originalText;
-                    DOM.databaseImportSnapshotBtn.disabled = false;
-                    clearInterval(interval);
-                }
-            }, 5000)
         }
         async function setDebugMode() {
             const data = {


### PR DESCRIPTION
Removes getDatabaseSnapshotDirectory, setDatabaseExportSnapshot, and setDatabaseImportSnapshot functions since they reference DOM elements that are commented out in the HTML template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)