### PR TITLE
Fix indexer status field flickering by checking DOM values before upd…

### DIFF
--- a/src/typescript/pages/settings.ts
+++ b/src/typescript/pages/settings.ts
@@ -216,8 +216,12 @@ import {Sleep} from "../util/time";
             if (response[0] === 200) {
                 DOM.indexerRunCheckbox.checked = response[1].indexerRunning;
                 if (response[1].indexerRunning == true) {
-                    DOM.indexerStatusText.textContent = "Warming Up";
-                    DOM.indexerStatusText.style.color = "#D3D3D3";
+                    if (DOM.indexerStatusText.textContent !== "Warming Up") {
+                        DOM.indexerStatusText.textContent = "Warming Up";
+                    }
+                    if (DOM.indexerStatusText.style.color !== "#D3D3D3") {
+                        DOM.indexerStatusText.style.color = "#D3D3D3";
+                    }
                 }
             }
         }
@@ -225,21 +229,29 @@ import {Sleep} from "../util/time";
             let response = await HttpGetJson("/settings/indexer/status");
             if (response[0] === 200) {
                 let status = DOMPurify.sanitize(response[1].status);
+                let newText = "";
+                let newColor = "";
                 if (status == "running") {
-                    DOM.indexerStatusText.textContent = "Running"
-                    DOM.indexerStatusText.style.color = "green";
+                    newText = "Running";
+                    newColor = "green";
                 } else if (status == "complete") {
-                    DOM.indexerStatusText.textContent = "Complete"
-                    DOM.indexerStatusText.style.color = "green";
+                    newText = "Complete";
+                    newColor = "green";
                 } else if (status == "stopped") {
-                    DOM.indexerStatusText.textContent = "Stopped"
-                    DOM.indexerStatusText.style.color = "#D3D3D3";
+                    newText = "Stopped";
+                    newColor = "#D3D3D3";
                 } else if (status == "failed") {
-                    DOM.indexerStatusText.textContent = "Failed"
-                    DOM.indexerStatusText.style.color = "red";
+                    newText = "Failed";
+                    newColor = "red";
                 } else {
-                    DOM.indexerStatusText.textContent = status;
-                    DOM.indexerStatusText.style.color = "yellow";
+                    newText = status;
+                    newColor = "yellow";
+                }
+                if (DOM.indexerStatusText.textContent !== newText) {
+                    DOM.indexerStatusText.textContent = newText;
+                }
+                if (DOM.indexerStatusText.style.color !== newColor) {
+                    DOM.indexerStatusText.style.color = newColor;
                 }
             } else {
                 LogError("Indexer Status Error");


### PR DESCRIPTION
…ating

The blockchain indexer status field was flickering on every refresh cycle because both getIndexerStatus() and getIndexerRunning() were updating the DOM unconditionally every 6 seconds, even when values hadn't changed.

Changes:
- Modified getIndexerStatus() to compare current textContent and color before updating, preventing unnecessary DOM modifications
- Modified getIndexerRunning() to check "Warming Up" status before setting
- Eliminates visual flicker by only updating DOM when values actually change

🤖 Generated with [Claude Code](https://claude.com/claude-code)